### PR TITLE
Expanding PROOF Repo for v1.0 Release

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at wilds@fredhutch.org. 
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+This outlines how to propose a change to the individual repositories involved in PROOF. For more detailed info about contributing to this, and other WILDS projects, please see the [**WILDS Contributing Guide**](https://getwilds.org/guide/). 
+
+## Fixing typos/docs changes
+
+You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the _source_ file. 
+
+## Bigger changes
+
+If you want to make a bigger change, it's a good idea to first file an issue and make sure someone from the team agrees that it’s needed. 
+
+If you’ve found a bug, please file an issue that illustrates the bug with a minimal reproducible example.
+
+### Pull request process
+
+*   Fork the package and clone onto your computer
+*   Create a Git branch for your pull request (PR)
+*   Make your changes, commit to git, and then create a pull request.
+    *   The title of your PR should briefly describe the change.
+    *   The body of your PR should contain `Fixes #issue-number`.
+*  For user-facing changes, add a bullet to the changelog file if there is one.
+
+### Code style
+
+*   New code should follow the [style guidelines](https://getwilds.org/guide/style.html) laid out in the WILDS Contributor Guide. 
+
+## Code of Conduct
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this project you agree to abide by its terms.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,1 +1,28 @@
-# PROOF 0.1.0
+### June 2024 - PROOF v1.0
+**What's New**
+- Users can now interact with data stored in S3 buckets within WDL workflows executed in PROOF! Just make sure to have your AWS CLI credentials [established in Rhino](https://sciwiki.fredhutch.org/scicomputing/access_credentials/#configure-aws-cli) and you can use the S3 path just like any other input.
+- GPU analysis is now possible via the `gpu` argument in your WDL task's runtime section! For an example, try running [this example script](https://github.com/getwilds/ww-test-workflows/blob/main/gpuMatrixMult/gpuMatrixMult.wdl) in the [ww-test-workflows](https://github.com/getwilds/ww-test-workflows) repo of the [DaSL WILDS](https://github.com/getwilds).
+- Additional features have been introduced to increase transparency in terms of the functionality of PROOF:
+    - New `/info` API endpoint provides details on which code base is being used.
+    - Server start date and time is now available on the "PROOF Server" tab.
+    - Documentation links have been added to the "Welcome" tab and automated server creation email for increased visibility.
+
+**Fixes**
+- The default location of the Apptainer cache directory has been moved from `scratch` to `/hpc/temp` to avoid previously reported linkage issues associated with `scratch`.
+- PROOF's underlying WSGI server has been switched from Waitress to Gunicorn for better scalability and efficiency.
+- Session persistence or "stickiness" has been added to the Shiny app to ensure users only speak to one instance at a time.
+- Table entries that are longer than usual will now be abbreviated to 150 characters or less to ensure a consistent display.
+- A linting GitHub action has been added to the GitHub repository for improved CI/CD. All issues identified by this linting action have also been resolved.
+
+### February 2024 - PROOF v0.1
+**What's New!**
+- PROOF has now grouped together all the components for setting up and configuring your database and Cromwell server so you don’t have to manually configure each part!
+- You can interact with PROOF in two improved ways when running your workflows:
+    - [PROOF Shiny App](https://cromwellapp.fredhutch.org/) - an easy to use interface for accessing and configuring workflows to run on our cluster
+    - Through the R clients [proofr](https://getwilds.org/proofr/) and [rcromwell](https://getwilds.org/rcromwell/) - combined these allow you to run WDL workflows on PROOF from your R console 
+- We’ve made some enhancements to the way you use PROOF including:
+    - Each user must login with your Fred Hutch credentials so that no one else can access or use your Cromwell server session
+    - Each user can only run one Cromwell server at a time so that you don’t lose track of your workflow sessions
+
+**Fixes**
+- No fixes just yet, we’re launching our product

--- a/README.md
+++ b/README.md
@@ -1,14 +1,37 @@
 # PROOF (PRoduction On-ramp for Optimization and Feasibility)
+PROOF (PRoduction On-ramp for Optimization and Feasibility) is a user-friendly tool designed for managing and executing WDL (Workflow Description Language) workflows using the Cromwell workflow manager. PROOF allows users to:
+- Automate all the backend configurations necessary to run your workflows instantly.
+- Validate, troubleshoot, assess performance, and run their workflows all under one roof.
+- Refine their workflows before potential transitions to cloud-based infrastructures, providing a ‘proofing’ resource of sorts.
+While it is currently configured to run on the Fred Hutch cluster, it is readily adaptable for local instances and/or instances hosted at other institutions. If interested, please email wilds@fredhutch.org with any questions.
 
 ## Repos:
 
-- proof-api: https://github.com/FredHutch/proof-api
-- shiny-cromwell: https://github.com/FredHutch/shiny-cromwell
-- rcromwell: https://github.com/getwilds/rcromwell
-- proofr: https://github.com/getwilds/proofr
+- [proof-api](https://github.com/FredHutch/proof-api): REST API for PROOF used to automate many/most of the startup/configuration steps of WDL workflow submission via Cromwell.
+    - Latest release: [v1.0.0](https://github.com/FredHutch/proof-api/releases/tag/v1.0.0)
+- [shiny-cromwell](https://github.com/FredHutch/shiny-cromwell): Shiny-based front end for PROOF that provides a point-and-click interface for new users.
+    - Latest release: [v1.0.0](https://github.com/FredHutch/shiny-cromwell/releases/tag/v1.0.0)
+- [rcromwell](https://github.com/getwilds/rcromwell): R package for interacting with Cromwell servers and the WDL workflows they manage.
+    - Latest release: [v3.2.1](https://github.com/getwilds/rcromwell/releases/tag/v3.2.1)
+- [proofr](https://github.com/getwilds/proofr): R package for interacting with the PROOF API mentioned above.
+    - Latest release: [v0.2](https://github.com/getwilds/proofr/releases/tag/v0.2)
 
 ## Docs:
 
-- product description: https://sciwiki.fredhutch.org/datascience/proof/
-- how to use proof: https://sciwiki.fredhutch.org/dasldemos/proof-how-to/
-- proof troubleshooting: https://sciwiki.fredhutch.org/dasldemos/proof-troubleshooting/
+- Product Description: https://sciwiki.fredhutch.org/datascience/proof/
+- How to Use PROOF: https://sciwiki.fredhutch.org/dasldemos/proof-how-to/
+- PROOF Troubleshooting: https://sciwiki.fredhutch.org/dasldemos/proof-troubleshooting/
+
+## Support:
+
+For general questions, reach out to the Fred Hutch Data Science Lab (DaSL) at wilds@fredhutch.org. For bugs and/or feature requests, if you know which repository is the most relevant for your bug/feature, please open an issue directly in the corresponding repository. If you are unclear which repository it belongs in, or if the bug/feature spans across multiple repositories, [open an issue](https://github.com/getwilds/proof/issues) in this overarching PROOF repository and the PROOF development team will file issues in the corresponding locations.
+
+## Contributing:
+
+If you would like to contribute to this project, see the [contribution guidelines](CONTRIBUTING.md) as well out our [WILDS Contributor Guide](https://getwilds.org/guide/) for more details.
+
+## License:
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for details.
+
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # PROOF (PRoduction On-ramp for Optimization and Feasibility)
+
+## Repos:
+
+- proof-api: https://github.com/FredHutch/proof-api
+- shiny-cromwell: https://github.com/FredHutch/shiny-cromwell
+- rcromwell: https://github.com/getwilds/rcromwell
+- proofr: https://github.com/getwilds/proofr
+
+## Docs:
+
+- product description: https://sciwiki.fredhutch.org/datascience/proof/
+- how to use proof: https://sciwiki.fredhutch.org/dasldemos/proof-how-to/
+- proof troubleshooting: https://sciwiki.fredhutch.org/dasldemos/proof-troubleshooting/


### PR DESCRIPTION
## Description
In anticipation of the release of PROOF v1.0, we wanted to add more meat to the overarching PROOF project repo:
- Expanding README.md to include details about each repository and their respective purposes.
- Adding release notes to the NEWS.md file of the repo.
- Providing additional governance files to describe contribution procedures and a code of conduct.

Very open to feedback if anything should be added/removed, just let me know. Thanks!

## Related Issues
- Fixes #1 
- Almost fixes #2, just need to cut the official release after merging this PR