### PR TITLE
Reverting to PROOF v1.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,21 +1,3 @@
-### December 2024 - PROOF v1.2
-**What's New**
-
-- **User Interface Upgrade**: After extensive user studies, we have redesigned the user interface of PROOF to 
-provide a better experience for our users throughout their research. By transitioning the framework of our 
-Shiny app to bslib, the new interface will provide:
-    - A cleaner and more modern-looking interface
-    - Improved usability for researchers with less scrolling
-    - An updated version of bootstrap for easier programming and improved performance
-
-**Fixes**
-
-- **Scratch Directory Requirement**: With `/fh/scratch/` becoming read-only in early December 2024, users will now be required to have an `/hpc/temp/` directory in order to use PROOF.
-- **Glob Functionality**: Because `/fh/scratch/` did not allow linkages, [globbing functionality](https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#glob) was disabled for PROOF, but now that users are moving to `/hpc/temp/`, users can now provide glob arrays as outputs.
-- **Other Minor Improvements**:
-    - Expanded functionality of "zombie killer" process
-    - No longer restricted to `rhino01`
-
 ### September 2024 - PROOF v1.1
 **What's New**
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ While it is currently configured to run on the Fred Hutch cluster, it is readily
 - [proof-api](https://github.com/FredHutch/proof-api): REST API for PROOF used to automate many/most of the startup/configuration steps of WDL workflow submission via Cromwell.
     - Latest release: [v1.2.1](https://github.com/FredHutch/proof-api/releases/tag/v1.2.1)
 - [shiny-cromwell](https://github.com/FredHutch/shiny-cromwell): Shiny-based front end for PROOF that provides a point-and-click interface for new users.
-    - Latest release: [v1.2.0](https://github.com/FredHutch/shiny-cromwell/releases/tag/v1.2.0)
+    - Latest release: [v1.1.0](https://github.com/FredHutch/shiny-cromwell/releases/tag/v1.1.0)
 - [rcromwell](https://github.com/getwilds/rcromwell): R package for interacting with Cromwell servers and the WDL workflows they manage.
     - Latest release: [v3.3.0](https://github.com/getwilds/rcromwell/releases/tag/v3.3.0)
 - [proofr](https://github.com/getwilds/proofr): R package for interacting with the PROOF API mentioned above.


### PR DESCRIPTION
## Description
- Due to performance issues, we decided to hold off on PROOF v1.2 while we remedy the situation.
- Just reverting the version number of shiny-cromwell to reflect current state and pulling back the release notes in NEWS.
